### PR TITLE
Fix ImportError: No module named importlib from Django 1.9 and higher…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,9 +2,15 @@ Changelog
 =========
 
 
+django-collectmessages 0.3
+--------------------------
+- Fix ImportError: No module named importlib from Django 1.9 and higher [mmaccari]
+
+
 django-collectmessages 0.2
 --------------------------
 - Fix naming conflict Django 1.8 [baraa]
+
 
 django-collectmessages 0.1
 --------------------------

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-collectmessages',
-    version='0.2',
+    version='0.3',
     packages=find_packages("src"),
     package_dir = {"": "src"},
     include_package_data=True,

--- a/src/collectmessages/management/commands/collect_messages.py
+++ b/src/collectmessages/management/commands/collect_messages.py
@@ -16,7 +16,12 @@ import os.path
 from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.core.management.base import CommandError
-from django.utils.importlib import import_module
+try:
+    # Django < 1.9
+    from django.utils.importlib import import_module
+except:
+    # Django >= 1.9
+    from importlib import import_module
 from polib import POFile
 
 from collectmessages.finders import BaseMessageFinder

--- a/src/collectmessages/management/commands/collect_messages.py
+++ b/src/collectmessages/management/commands/collect_messages.py
@@ -19,7 +19,7 @@ from django.core.management.base import CommandError
 try:
     # Django < 1.9
     from django.utils.importlib import import_module
-except:
+except ImportError:
     # Django >= 1.9
     from importlib import import_module
 from polib import POFile


### PR DESCRIPTION
… (PTS-348)